### PR TITLE
Fixed encoding for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MobaTools
 | 1.1.4 | 2019-09-25 | check for setting speed to 0 ( this is not allowed, will be changed to '1' internally )
 | | | fix error when setting targetposition repetitive very fast
 | | | allow higher steprates (up to 2500 steps/sec)at the expense of higher relative jitter at these rates
-| | | ( absolute jitter is 200µs )
+| | | ( absolute jitter is 200Âµs )
 | 1.1.3 | 2019-08-22 | fix errors when converting angle to microseconds and vice versa in servo class
 | | | fix errors when converting angle to steps and vice versa in stepper class
 | | | no more warnings


### PR DESCRIPTION
Das kaputte Smiley in der README hat mich die ganze Zeit gestört ;-).
Hier ist die Datei mit UTF-8 codiert, so dass sowohl das micro-Symbol als auch der Smiley richtig angezeigt werden.