### PR TITLE
Adding ATtiny 2 series support

### DIFF
--- a/src/MobaTools.h
+++ b/src/MobaTools.h
@@ -178,7 +178,10 @@
 	#elif defined ARDUINO_AVR_UNO_WIFI_REV2
 		// SPI-SS for UNO Rev2 WiFi 
 		#define MoToSS 8		// Rev2 has no standard SS ( standard is pin22, which is not connected to anything )
-	#else
+  #elif defined __AVR_TINY_2__
+    // SPI SS for ATtiny 2 series
+    #define MoToSS PIN_PA4	// Standard for ATtiny 2 series is pin PA4(0);
+  #else
 		// default for other ( are there any?) boards or megaCoreX core
 		#define MoToSS 8		// standard for other boards
 	#endif

--- a/src/megaTinyAVR/MoToMegaTinyAVR.cpp
+++ b/src/megaTinyAVR/MoToMegaTinyAVR.cpp
@@ -1,0 +1,128 @@
+// AVR HW-spcific Functions
+#if defined ARDUINO_ARCH_MEGAAVR
+
+#if defined (MEGATINYCORE)
+
+#include <MobaTools.h>
+#define debugTP
+//#define debugPrint
+#include <utilities/MoToDbg.h>
+
+#warning "TIMER HW specfic - megatinyavr ---"
+#ifndef MILLIS_USE_TIMERB1
+  #error "This sketch is written for use with TCB1 as the millis timing source"
+#endif
+
+uint8_t noStepISR_Cnt;   // Counter for nested StepISr-disable
+
+nextCycle_t nextCycle;
+static nextCycle_t cyclesLastIRQ = 1;  // cycles since last IRQ
+// ---------- OCRxB Compare Interrupt used for stepper motor and Softleds ----------------
+void stepperISR(uint8_t cyclesLastIRQ) __attribute__ ((weak));
+void softledISR(uint8_t cyclesLastIRQ) __attribute__ ((weak));
+
+// reenabling interrupts within an ISR
+__attribute(( naked, noinline )) void isrIrqOn () { asm("reti"); }
+
+
+ISR ( TCA0_CMP1_vect) {
+    uint16_t tmp;
+  // Timer TCA0 Compare 1, used for stepper motor, starts every CYCLETIME us
+    // 26-09-15 An Interrupt is only created at timeslices, where data is to output
+    SET_TP1;
+	TCA0.SINGLE.INTFLAGS = TCA_SINGLE_CMP1_bm;	// Reset IRQ-flag
+
+    nextCycle = ISR_IDLETIME  / CYCLETIME ;// min ist one cycle per IDLETIME
+    if ( stepperISR ) stepperISR(cyclesLastIRQ);
+    //============  End of steppermotor ======================================
+   if ( softledISR ) softledISR(cyclesLastIRQ);
+    // ======================= end of softleds =====================================
+    // set compareregister to next interrupt time;
+    // compute next IRQ-Time in us, not in tics, so we don't need long
+    noInterrupts(); // when manipulating 16bit Timerregisters IRQ must be disabled (mandatory for Mega4809!!!)
+    if ( nextCycle == 1 )  {
+        //CLR_TP1;
+        // this is timecritical: Was the ISR running longer then CYCELTIME?
+        // compute length of current IRQ ( which startet at OCRxB )
+        // we assume a max. runtime of 1000 Tics ( = 500µs , what nevver should happen )
+        tmp = GET_COUNT - OCRxB ;
+        if ( tmp > 1000 ) tmp += TIMER_OVL_TICS; // there was a timer overflow
+        if ( tmp > (CYCLETICS-10) ) {
+            // runtime was too long, next IRQ mus be started immediatly
+            //SET_TP3;
+            tmp = GET_COUNT+10; 
+        } else {
+            tmp = OCRxB + CYCLETICS;
+        }
+        OCRxB = ( tmp > TIMER_OVL_TICS ) ? tmp -= TIMER_OVL_TICS : tmp ;
+        //SET_TP1;
+    } else {
+        // time till next IRQ is more then one cycletime
+        tmp = ( OCRxB + (nextCycle * CYCLETICS) );
+        if ( tmp >= TIMER_OVL_TICS ) tmp = tmp - TIMER_OVL_TICS;
+        OCRxB = tmp ;
+    }
+    interrupts();
+    cyclesLastIRQ = nextCycle;
+    CLR_TP1; // Oszimessung Dauer der ISR-Routine
+}
+////////////////////////////////////////////////////////////////////////////////////////////
+
+void seizeTimerAS() {
+    static bool timerInitialized = false;
+    if ( !timerInitialized ) {
+        // using timer TCA0 in normal mode.
+        // CMP0 register used for steppers and softleds
+        // CMP1 register used for servos
+		// CMP2	register (not yet )used for  softleds
+        noInterrupts();
+        takeOverTCA0();
+        // TCA0.SINGLE.CTRLESET = TCA_SINGLE_CMD_RESET_gc;     // hard reset timer // Not required because of takeOverTCA0()
+        // For ATtiny with megaTinyCore, we can use DIV8 prescaler since millis() uses TCB1
+        TCA0.SINGLE.CTRLA = TCA_SINGLE_CLKSEL_DIV8_gc;      // 0.5µs per tic with 16MHz clock
+        // TCA0.SINGLE.CTRLA = TCA_SINGLE_CLKSEL_DIV64_gc;      // 0.5µs per tic with 16MHz clock
+        // On standard megaAVR we would need to use DIV64: TCA0.SINGLE.CTRLA = TCA_SINGLE_CLKSEL_DIV64_gc;
+        // megaTinyCore allows a prescaler of 2 for TCB1 for millis(), so changing TCA0 doesn't influence millis()
+        TCA0.SINGLE.CTRLB = TCA_SINGLE_WGMODE_NORMAL_gc;    // normal mode, no autolockUpdate, no pins active
+        TCA0.SINGLE.CTRLC = 0;
+        TCA0.SINGLE.CTRLD = 0;                              // no split mode ( user 16bit timer )
+        //TCA0.SINGLE.CTRLECLR                              // wasn't used in megaavr code - not sure what it would do here
+        TCA0.SINGLE.CTRLESET = TCA_SINGLE_LUPD_bm;          // don't use buffered compare registes
+        //TCA0.SINGLE.CTRLFCLR                              / wasn't used in megaavr code - not sure what it would do here
+        //TCA0.SINGLE.CTRLFSET                              // wasn't used in megaavr code - not sure what it would do here
+        TCA0.SINGLE.INTCTRL = TCA_SINGLE_CMP0_bm | TCA_SINGLE_CMP1_bm; // enable cmp0 and cmp1 interrupt
+        TCA0.SINGLE.INTFLAGS = 0;   // clear all interrupts
+        TCA0.SINGLE.PER  = TIMERPERIODE * TICS_PER_MICROSECOND;  // timer periode is 20000us
+        TCA0.SINGLE.CMP0 = FIRST_PULSE;
+        TCA0.SINGLE.CMP1 = 400; //CPM1 
+        TCA0.SINGLE.CTRLA |= TCA_SINGLE_ENABLE_bm;          // Enable the timer
+        interrupts();
+        timerInitialized = true;
+        MODE_TP1;   // set debug-pins to Output
+        MODE_TP2;
+        MODE_TP3;
+        MODE_TP4;
+        DB_PRINT("CYCLETICS=%d, TIMER_OVL_TICS=%d", CYCLETICS, TIMER_OVL_TICS );
+    }
+}
+
+extern uint8_t spiStepperData[2]; // step pattern to be output on SPI
+
+ISR ( SPI0_INT_vect ) {
+    //SET_TP4;
+    // Because of buffered SPI, both bytes have already been written to SPI HW
+	// This IRQ fires, if both bytes have been shifted out
+    SET_SS;
+	SPI0_INTFLAGS = SPI_TXCIF_bm;     // Clear transfer complete flag
+    //CLR_TP4;
+
+}
+
+
+void enableSoftLedIsrAS() {
+}
+
+
+#endif
+
+#endif

--- a/src/megaTinyAVR/MoToMegaTinyAVR.h
+++ b/src/megaTinyAVR/MoToMegaTinyAVR.h
@@ -1,0 +1,124 @@
+#ifndef MOTOMEGATINYAVR_H
+#define MOTOMEGATINYAVR_H
+// AVR specific defines for Cpp files
+
+#warning megaTinyAVR specific cpp includes
+
+void seizeTimerAS();
+// reenabling interrupts within an ISR
+__attribute(( naked, noinline )) void isrIrqOn ();
+
+extern uint8_t noStepISR_Cnt;   // Counter for nested StepISr-disable
+
+// _noStepIRQ und _stepIRQ werden in servo.cpp und stepper.cpp genutzt
+static inline __attribute__((__always_inline__)) void _noStepIRQ() {
+        TCA0_SINGLE_INTCTRL &= ~TCA_SINGLE_CMP1_bm ; 
+    noStepISR_Cnt++;
+    #if defined COMPILING_MOTOSTEPPER_CPP
+    //#warning "COMPILING_MOTOSTEPPER_CPP"
+    SET_TP3;
+    #endif
+    interrupts(); // allow other interrupts
+}
+
+static inline __attribute__((__always_inline__)) void  _stepIRQ(bool force = false) {
+    if ( force ) noStepISR_Cnt = 1; //enable IRQ immediately
+    if ( noStepISR_Cnt > 0 ) noStepISR_Cnt -= 1; // don't decrease if already 0 ( if enabling IRQ is called too often )
+    if ( noStepISR_Cnt == 0 ) {
+        #if defined COMPILING_MOTOSTEPPER_CPP
+            CLR_TP3;
+        #endif
+        TCA0_SINGLE_INTCTRL |= TCA_SINGLE_CMP1_bm ; 
+    }
+}
+
+static inline __attribute__((__always_inline__)) void nestedInterrupts() {
+	//to reenable interrupts within an ISR
+	isrIrqOn ();
+}
+/////////////////////////////////////////////////////////////////////////////////////////////////
+#if defined COMPILING_MOTOSERVO_CPP
+// Values for Servo: -------------------------------------------------------
+constexpr uint8_t INC_PER_MICROSECOND = 8;		// one speed increment is 0.125 µs
+constexpr uint8_t  COMPAT_FACT = 1; // no compatibility mode for this board                     
+// defaults for macros that are not defined in architecture dependend includes
+constexpr uint8_t INC_PER_TIC = INC_PER_MICROSECOND / TICS_PER_MICROSECOND;
+#define time2tic(pulse)  ( (pulse) *  INC_PER_MICROSECOND )
+#define tic2time(tics)  ( (tics) / INC_PER_MICROSECOND )
+#define AS_Speed2Inc(speed) (speed)
+
+
+static inline __attribute__((__always_inline__)) void enableServoIsrAS() {
+    // enable compare-A interrupt
+    TCA0_SINGLE_INTCTRL |= TCA_SINGLE_CMP0_bm ; 
+}
+
+#define setServoCmpAS(x)		// ignore this call
+
+#endif // COMPILING_MOTOSERVO_CPP
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+#if defined COMPILING_MOTOSOFTLED_CPP
+
+#endif // COMPILING_MOTOSOFTLED_CPP
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// Wird auch in MoToMegaAVR.cpp gebraucht ( SPI-Interrupt )
+extern volatile PORT_t  *portSS;
+extern uint8_t bitSS;
+#define SET_SS portSS->OUTSET = bitSS 
+#define CLR_SS portSS->OUTCLR = bitSS 
+#if defined COMPILING_MOTOSTEPPER_CPP
+    static uint8_t spiInitialized = false;
+    // Macros für fast setting of SS Port	
+    volatile PORT_t  *portSS;
+    uint8_t bitSS;
+
+    static inline __attribute__((__always_inline__)) void initSpiAS() {
+        if ( spiInitialized ) return;
+        // initialize SPI hardware.
+        // MSB first, default Clk Level is 0, shift on leading edge
+        const uint8_t oldSREG = SREG;
+        cli();
+		// MOSI,MISO ans SCK are the standard pins corresponding to the selected board
+        pinMode( MOSI, OUTPUT );
+        pinMode( SCK, OUTPUT );
+		// SS is driven by MobaTools and can be any pin ( defined in MobaTools.h )
+		// default is pin 8 for Nano Every and UNO Rev2 WiFi
+        portSS = digitalPinToPortStruct(MoToSS);
+        bitSS = digitalPinToBitMask(MoToSS);
+        pinMode( MoToSS, OUTPUT );
+		// Map SPI0-pins  
+        PORTMUX_SPIROUTEA &=  ~PORTMUX_SPI0_gm; // Clear SPI-Bits
+        PORTMUX_SPIROUTEA |=  SPI_MUX; // set MUX according to Board    
+		// SPI-Mode 0 mit Sendebuffer ( 2.byte kann sofort geschrieben werden )
+		// SPI0_CTRLB = SPI_MODE_0_gc | SPI_BUFEN_bm | SPI_BUFWR_bm | SPI_SSD_bm;
+		SPI0_CTRLB = SPI_MODE_0_gc | SPI_BUFEN_bm | SPI_BUFWR_bm | SPI_SSD_bm;
+		SPI0_INTCTRL = SPI_TXCIE_bm;     // Using Transfer complete ISR
+		SPI0_CTRLA =  SPI_PRESC_DIV4_gc |      // prescaler 4 / 4Mhz SPI clk
+					( 1 << SPI_MASTER_bp ) | // Master Mode
+					( 0 << SPI_DORD_bp ) |   // MSB first
+					( 1 << SPI_ENABLE_bp );     // SPI enable
+        //digitalWrite( SS, HIGH );
+        SET_SS;
+        SREG = oldSREG;  // undo cli() 
+        spiInitialized = true;  
+    }
+
+    static inline __attribute__((__always_inline__)) void startSpiWriteAS( uint8_t spiData[] ) {
+        //digitalWrite( SS, LOW );
+        CLR_SS;
+        SPI0_DATA = spiData[1];
+        SPI0_DATA = spiData[0];
+    }    
+    
+    
+ 
+static inline __attribute__((__always_inline__)) void enableStepperIsrAS() {
+        TCA0_SINGLE_INTCTRL |= TCA_SINGLE_CMP1_bm ;  
+}
+
+#endif // COMPILING_MOTOSTEPPER_CPP
+
+
+#endif

--- a/src/megaTinyAVR/drivers.h
+++ b/src/megaTinyAVR/drivers.h
@@ -1,0 +1,43 @@
+#ifndef MEGATINYAVR_DRIVER_H
+#define MEGATINYAVR_DRIVER_H
+//////////////////////////////////////// processor dependent defines and declarations //////////////////////////////////////////
+//vvvvvvvvvvvvvvvvvvvvvvvvvvvvv  megaTinyAVR ATTiny 2 Series (3226 / 3227) vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+/* MobaTools uses Timer/Counter 0 (TCA0) ATTiny 2 Series. MegaTinyCore allows the prescaler of TCA0 to be independent from TCB1, 
+   used for millis() (set at /2), so we can use a prescaler of 8 = 0.5µs per tic.
+*/
+
+//#include <avr/interrupt.h>
+#define IRAM_ATTR       // delete in .cpp files, because it has no meaning for megaAVR processors
+#define DRAM_ATTR
+
+
+#define FAST_PORTWRT        // if this is defined, ports are written directly in IRQ-Routines,
+                            // not with 'digitalWrite' functions
+#if defined(MEGATINYCORE) && defined(MILLIS_USE_TIMERB1)
+// For ATtiny with megaTinyCore - can use prescaler of 8 = 0.5µs per tic
+#define TICS_PER_MICROSECOND (F_CPU / 1000000.0 / 8) // the clockCyclesPerMicrosecond() call inhibits compiletime evaluation
+#if F_CPU != 16000000
+    #error "Only 16MHz is supported. Other frequcies are not tested."
+#endif
+#else
+    #error "Not supported"
+#endif
+
+// define timer to use
+// defines specially für ATTiny 2 Series.
+// Timer TCA0 is used, prescaler fixed at 8
+// CMP0: for servos
+// CMP1: for stepper and softleds
+// CMP2: possible own ISR for softleds? ( not yet implemented )
+
+#define OCRxA   TCA0.SINGLE.CMP0
+#define OCRxB   TCA0.SINGLE.CMP1
+#define GET_COUNT   TCA0.SINGLE.CNT
+#define TIMERx_COMPA_vect   TCA0.CMP0.vect
+#define TIMERx_COMPB_vect   TCA0.CMP1.vect
+#define TIMERx_COMPC_vect   TCA0.CMP2.vect
+#define TIMSKx     TCA0.SINGLE.INTCTRL
+#define OCIExB
+
+#define ARCHITECT_INCLUDE <megaTinyAVR/MoToMegaTinyAVR.h>
+#endif

--- a/src/megaTinyAVR/driversMegaTinyAVR.c
+++ b/src/megaTinyAVR/driversMegaTinyAVR.c
@@ -1,0 +1,7 @@
+// AVR HW-spcific Functions
+#if defined(ARDUINO_ARCH_MEGAAVR) && defined (MEGATINYCORE)
+#include <Arduino.h>
+#include "drivers.h"
+
+#warning "HW specfic - megatinyavr ---"
+#endif

--- a/src/utilities/MoToBase.h
+++ b/src/utilities/MoToBase.h
@@ -14,7 +14,11 @@
 #ifdef ARDUINO_ARCH_AVR
 	#include <avr/drivers.h>
 #elif defined ARDUINO_ARCH_MEGAAVR
-	#include <megaAVR/drivers.h>
+	#if defined __AVR_TINY_2__
+		#include <megaTinyAVR/drivers.h>
+	#else
+		#include <megaAVR/drivers.h>
+	#endif	
 #elif defined ARDUINO_ARCH_STM32F1
 	#include <stm32f1/drivers.h>
 #elif defined ARDUINO_ARCH_STM32F4
@@ -62,7 +66,7 @@
 #endif
 extern nextCycle_t nextCycle;   // to be used in ISR for stepper and softled
 
-#define ISR_IDLETIME    5000        // max time between two Stepper/Softled ISRs ( µsec )
+#define ISR_IDLETIME    5000        // max time between two Stepper/Softled ISRs ( Âµsec )
 
 // old Class names ( for compatibility with former sketches )
 #define Stepper4    MoToStepper
@@ -81,7 +85,7 @@ extern nextCycle_t nextCycle;   // to be used in ISR for stepper and softled
 
 // internal defines
 
-#define TIMERPERIODE    20000   // Timer Overflow in µs
+#define TIMERPERIODE    20000   // Timer Overflow in Âµs
 //#define TIMER_OVL_TICS  ( TIMERPERIODE*TICS_PER_MICROSECOND )
 constexpr uint16_t TIMER_OVL_TICS = ( TIMERPERIODE*TICS_PER_MICROSECOND );
 

--- a/src/utilities/MoToDbg.h
+++ b/src/utilities/MoToDbg.h
@@ -197,6 +197,21 @@
         #define MODE_TP4  pinMode(TP4,OUTPUT ) 
         #define SET_TP4   gpio_set_mask( 1<<TP4 )
         #define CLR_TP4  gpio_clr_mask( 1<<TP4 )
+    
+    #elif defined (__AVR_TINY_2__)
+        #warning "Debug-Ports ATtiny active"
+        #define MODE_TP1 pinMode( PIN_PA5, OUTPUT )
+        #define SET_TP1 PORTA.OUTSET = PIN5_bm
+        #define CLR_TP1 PORTA.OUTCLR = PIN5_bm
+        #define MODE_TP2 pinMode( PIN_PA6, OUTPUT )
+        #define SET_TP2 PORTA.OUTSET = PIN6_bm
+        #define CLR_TP2 PORTA.OUTCLR = PIN6_bm
+        #define MODE_TP3
+        #define SET_TP3
+        #define CLR_TP3
+        #define MODE_TP4
+        #define SET_TP4
+        #define CLR_TP4
  
 	#else // processor not known
 		//#warning "no testpins - processor unknown"


### PR DESCRIPTION
Resolves #49 

These updates have been tested on an ATtiny 3226 and 3227 using megaTinyCore. It is likely that other 2 series parts with enough Flash + RAM would also work. 

I have tested that the library functions; button, timer, servo, softled. I have not tested stepper. 

